### PR TITLE
Add new gala_compatibility module.

### DIFF
--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -15,7 +15,7 @@
 ############################################################################
 
 import lldb
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 
 class error(RuntimeError):
@@ -261,7 +261,7 @@ class Type(object):
         return self._sbtype_object
 
     def _is_baseclass(
-            self, baseclass_sbtype: lldb.SBType) -> tuple[bool, Optional[int]]:
+            self, baseclass_sbtype: lldb.SBType) -> Tuple[bool, Optional[int]]:
         base_sbtype = Type(baseclass_sbtype).strip_typedefs().sbtype()
         self_sbtype = self.strip_typedefs().sbtype()
         for i in range(self_sbtype.GetNumberOfDirectBaseClasses()):
@@ -346,7 +346,7 @@ class Type(object):
     def pointer(self) -> 'Type':
         return Type(self._sbtype_object.GetPointerType())
 
-    def template_argument(self, n: int) -> 'Type | Value':
+    def template_argument(self, n: int) -> Union['Type', 'Value']:
         # TODO: This is woefully incomplete!
         return Type(self._sbtype_object.GetTemplateArgumentType(n))
 
@@ -414,13 +414,13 @@ class Value(object):
     def sbvalue(self) -> lldb.SBValue:
         return self._sbvalue_object
 
-    def _stripped_sbtype(self) -> tuple[lldb.SBType, int]:
+    def _stripped_sbtype(self) -> Tuple[lldb.SBType, int]:
         sbtype = self._sbvalue_object.GetType()
         stripped_sbtype = Type(sbtype).strip_typedefs().sbtype()
         type_class = stripped_sbtype.GetTypeClass()
         return stripped_sbtype, type_class
 
-    def _as_number(self) -> int | float:
+    def _as_number(self) -> Union[int, float]:
         sbtype, _ = self._stripped_sbtype()
         type_flags = sbtype.GetTypeFlags()
         if type_flags & lldb.eTypeIsEnumeration:
@@ -454,7 +454,7 @@ class Value(object):
         return numval
 
     def _binary_op(self,
-                   other: 'Value | int | float',
+                   other: Union['Value', int, float],
                    op: int,
                    reverse: bool = False) -> 'Value':
         sbtype, type_class = self._stripped_sbtype()
@@ -551,7 +551,7 @@ class Value(object):
         return Value(self._sbvalue_object.CreateValueFromData(
             '', data, result_type))
 
-    def _cmp(self, other: 'Value | int | float') -> int:
+    def _cmp(self, other: Union['Value', int, float]) -> int:
         if (isinstance(other, int) or isinstance(other, float)):
             other_val = other
         elif isinstance(other, Value):
@@ -667,30 +667,30 @@ class Value(object):
         return Value(self._sbvalue_object.CreateValueFromAddress(
              "", new_addr, elem_sbtype))
 
-    def __add__(self, number: 'Value | int | float') -> 'Value':
+    def __add__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_ADD)
 
-    def __radd__(self, number: 'Value | int | float') -> 'Value':
+    def __radd__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_ADD, reverse=True)
 
-    def __sub__(self, number: 'Value | int | float') -> 'Value':
+    def __sub__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_SUB)
 
-    def __rsub__(self, number: 'Value | int | float') -> 'Value':
+    def __rsub__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_SUB, reverse=True)
 
-    def __mul__(self, number: 'Value | int | float') -> 'Value':
+    def __mul__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_MUL)
 
-    def __rmul__(self, number: 'Value | int | float') -> 'Value':
+    def __rmul__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_MUL, reverse=True)
 
     # gdb with python3 uses the truediv (/) operator, but still does integer
     # division.
-    def __truediv__(self, number: 'Value | int | float') -> 'Value':
+    def __truediv__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_TRUEDIV)
 
-    def __rtruediv__(self, number: 'Value | int | float') -> 'Value':
+    def __rtruediv__(self, number: Union['Value', int, float]) -> 'Value':
         return self._binary_op(number, OP_TRUEDIV, reverse=True)
 
     def __bool__(self) -> bool:
@@ -704,52 +704,52 @@ class Value(object):
         else:
             return self._sbvalue_object.IsValid()
 
-    def __eq__(self, other: 'Value | int | float') -> bool:
+    def __eq__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) == 0
 
-    def __ne__(self, other: 'Value | int | float') -> bool:
+    def __ne__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) != 0
 
-    def __lt__(self, other: 'Value | int | float') -> bool:
+    def __lt__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) < 0
 
-    def __le__(self, other: 'Value | int | float') -> bool:
+    def __le__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) <= 0
 
-    def __gt__(self, other: 'Value | int | float') -> bool:
+    def __gt__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) > 0
 
-    def __ge__(self, other: 'Value | int | float') -> bool:
+    def __ge__(self, other: Union['Value', int, float]) -> bool:
         return self._cmp(other) >= 0
 
-    def __and__(self, other: 'Value | int | float') -> 'Value':
+    def __and__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_AND)
 
-    def __rand__(self, other: 'Value | int | float') -> 'Value':
+    def __rand__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_AND, reverse=True)
 
-    def __or__(self, other: 'Value | int | float') -> 'Value':
+    def __or__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_OR)
 
-    def __ror__(self, other: 'Value | int | float') -> 'Value':
+    def __ror__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_OR, reverse=True)
 
-    def __xor__(self, other: 'Value | int | float') -> 'Value':
+    def __xor__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_XOR)
 
-    def __rxor__(self, other: 'Value | int | float') -> 'Value':
+    def __rxor__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_BITWISE_XOR, reverse=True)
 
-    def __lshift__(self, other: 'Value | int | float') -> 'Value':
+    def __lshift__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_LSHIFT)
 
-    def __rlshift__(self, other: 'Value | int | float') -> 'Value':
+    def __rlshift__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_LSHIFT, reverse=True)
 
-    def __rshift__(self, other: 'Value | int | float') -> 'Value':
+    def __rshift__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_RSHIFT)
 
-    def __rrshift__(self, other: 'Value | int | float') -> 'Value':
+    def __rrshift__(self, other: Union['Value', int, float]) -> 'Value':
         return self._binary_op(other, OP_RSHIFT, reverse=True)
 
     def __invert__(self) -> 'Value':
@@ -936,18 +936,22 @@ def lookup_type(name, block=None) -> Type:
 
 
 class Objfile:
-    pass
+    pass  # This class is just a stub for gdb.Objfile for now.
 
 
 def current_objfile() -> Optional[Objfile]:
+    # This function should return the current Objfile, if any. But objfiles are
+    # not implemented in GALA, so we always return None.
     return None
 
 
 class Progspace:
-    pass
+    pass  # This class is just a stub for gdb.Progspace for now.
 
 
 def current_progspace() -> Optional[Progspace]:
+    # This function should return the current Progspace. But progspaces are not
+    # implemented in GALA, so we always return None.
     return None
 
 

--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -309,6 +309,17 @@ class PrettyPrinter:
                 '__call__ must be defined in the PrettyPrinter subclass')
 
 
+class SubPrettyPrinter:
+    """A base sub-prettyprinter class
+
+    gdb doesn't require prettyprinter classes to derive from this, but gives
+    script authors the option to do so, so we implement it as well.
+    """
+    def __init__(self, name):
+        self.name = name
+        self.enabled = True
+
+
 class RegexpCollectionPrettyPrinter(PrettyPrinter):
     """Implements a collection of prettyprinters with regexp matching.
 

--- a/gdb_modules/README.md
+++ b/gdb_modules/README.md
@@ -1,0 +1,6 @@
+# GALA gdb compatibility modules
+
+This directory contains Python libraries that are intended to run under both gdb
+and lldb-with-GALA. The goal is to encapsulate functionality that can't be
+provided in a 100% gdb-compatible way. This way, a script can remain compatible
+with both debuggers.

--- a/gdb_modules/gala_compatibility.py
+++ b/gdb_modules/gala_compatibility.py
@@ -13,7 +13,7 @@ class TypeCallbackPrettyPrinter(gdb.printing.PrettyPrinter):
   # implementation of `gdb.register_pretty_printer()` uses the
   # `gala_matching_function` and `gala_make_printer_function` subprinter
   # attributes to drive callback-based formatter registration in LLDB.
-  class Subprinter:
+  class Subprinter(gdb.printing.SubPrettyPrinter):
 
     def __init__(self, name, matching_function, make_printer_function):
       self.enabled = True

--- a/gdb_modules/gala_compatibility.py
+++ b/gdb_modules/gala_compatibility.py
@@ -1,0 +1,43 @@
+"""GALA compatibility classes.
+
+These classes expose lldb functionality that doesn't have an exact equivalent in
+the gdb API, in a way that's compatible with both debuggers.
+"""
+import gdb
+import gdb.printing
+
+class TypeCallbackPrettyPrinter(gdb.printing.PrettyPrinter):
+  """A type-callback prettyprinter compatible with GDB and lldb-with-GALA."""
+
+  # The Subprinter class doesn't have any logic. We need it here because GALA's
+  # implementation of `gdb.register_pretty_printer()` uses the
+  # `gala_matching_function` and `gala_make_printer_function` subprinter
+  # attributes to drive callback-based formatter registration in LLDB.
+  class Subprinter:
+
+    def __init__(self, name, matching_function, make_printer_function):
+      self.enabled = True
+      self.name = name
+      self.gala_matching_function = matching_function
+      self.gala_make_printer_function = make_printer_function
+
+  def __init__(self, name, matching_function, make_printer_function):
+    """Builds a TypeCallbackPrettyPrinter.
+
+    Args:
+      - name: a string to identify the prettyprinter.
+      - matching_function: a function that takes a gdb.Type and returns True iff
+                           we should use this prettyprinter.
+      - make_printer_function: a function that takes a gdb.Value and returns a
+                               gdb prettyprinter object.
+    """
+    subprinter = self.Subprinter(name, matching_function, make_printer_function)
+    super(TypeCallbackPrettyPrinter, self).__init__(name, [subprinter])
+
+  def __call__(self, val):
+    sp = self.subprinters[0]
+    if sp.gala_matching_function(val.type):
+      return sp.gala_make_printer_function(val)
+    return None
+
+

--- a/test/lit/TypeCallbackPrettyPrinter.test
+++ b/test/lit/TypeCallbackPrettyPrinter.test
@@ -1,0 +1,22 @@
+Checks that gala_compatibility.TypeCallbackPrettyPrinter works.
+
+RUN: %clangxx -g -o %t TypeCallbackPrettyPrinter/test_program.cc
+RUN: %lldb -b \
+RUN:       -o 'script import TypeCallbackPrettyPrinter' \
+RUN:       -o 'b main' \
+RUN:       -o 'r' \
+RUN:       -o 'p s1' \
+RUN:       -o 'p s2' \
+RUN:       -o 'p s3' %t | FileCheck %s
+
+skip lldb output until our first print command
+CHECK: p s1
+CHECK: A class with an X member. X = 1234
+
+CHECK: p s2
+CHECK: A class with an X member. X = 5678
+
+CHECK: p s3
+CHECK-NOT: A class with an X member
+CHECK: 9999
+

--- a/test/lit/TypeCallbackPrettyPrinter/__init__.py
+++ b/test/lit/TypeCallbackPrettyPrinter/__init__.py
@@ -1,0 +1,23 @@
+import gdb
+import gdb.printing
+import gdb.types
+from gala_compatibility import TypeCallbackPrettyPrinter
+
+class ClassWithMemberNamedXPrinter(gdb.printing.PrettyPrinter):
+  def __init__(self, val):
+    self.val = val
+
+  def to_string(self):
+    return "A class with an X member. X = %d" % self.val["x"]
+
+
+def has_x(t):
+  try:
+    return gdb.types.has_field(t, "x")
+  except:
+    return False
+
+
+printer = TypeCallbackPrettyPrinter(
+    "class-with-member-named-x", has_x, ClassWithMemberNamedXPrinter)
+gdb.printing.register_pretty_printer(gdb.current_objfile(), printer)

--- a/test/lit/TypeCallbackPrettyPrinter/test_program.cc
+++ b/test/lit/TypeCallbackPrettyPrinter/test_program.cc
@@ -1,0 +1,20 @@
+// Two different unrelated structs so we can test if type-callback matching
+// works. In this case we'll match any type with a member named "x".
+struct S1 {
+  int x;
+};
+
+struct S2 {
+  int x;
+};
+
+// A negative example.
+struct S3 {
+  int y;
+};
+
+S1 s1 = {1234};
+S2 s2 = {5678};
+S3 s3 = {9999};
+
+int main() { return 0; }

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -9,7 +9,9 @@ config.suffixes = [".test"]
 # Add the root GALA directory to PYTHONPATH so we can `import gdb`.
 test_directory = Path(__file__).resolve().parent
 gala_directory = test_directory.parent.parent
-config.environment['PYTHONPATH'] = os.pathsep.join([str(gala_directory)])
+config.environment['PYTHONPATH'] = os.pathsep.join([
+    str(gala_directory), str(gala_directory / 'gdb_modules')
+])
 
 # Substitutions for common tools. Assume them to be in the PATH for now.
 config.substitutions.append( ('%clangxx', 'clang++') )


### PR DESCRIPTION
This module will contain compatibility helpers that work under both gdb and lldb-with-GALA. For now, this change just adds a new class `TypeCallbackPrettyPrinter` that serves as a portable abstraction for type-based callback registration in both debuggers, similar to what `gdb.printing.RegexpCollectionPrettyPrinter` does for regex-based registration.