### PR TITLE
Adjusting the type hints to work with older version of python

### DIFF
--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -23,7 +23,7 @@ import re
 import sys
 import traceback
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 
 # Type aliases for different lldb and gdb callable types.
@@ -147,7 +147,7 @@ def _set_current_target(method: Callable) -> Callable:
 
 
 def _named_sbvalue(
-        parent: lldb.SBValue, name: str, v: gdb.Value | int | str
+        parent: lldb.SBValue, name: str, v: Union[gdb.Value, int, str]
 ) -> lldb.SBValue:
     """Creates an SBValue equivalent to `v`, but with name `name`.
 


### PR DESCRIPTION
The type hint uses a python3 syntax introduced in python 3.10. Some platforms like Xcode 15 (the latest release) are still using python 3.9 and cannot be upgraded by the user. Using the older syntax allows for these scripts to work with older versions of python3.