### PR TITLE
Short-circuit lookup_type for builtin types

### DIFF
--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -987,6 +987,8 @@ def parse_and_eval(expr) -> Value:
 
 
 def lookup_type(name, block=None) -> Type:
+    if name in BUILTIN_TYPE_NAME_TO_BASIC_TYPE:
+        return Type(get_builtin_sbtype(name))
     chunks = name.split('::')
     unscoped_name = chunks[-1]
     typelist = gala_get_current_target().FindTypes(unscoped_name)
@@ -1001,11 +1003,6 @@ def lookup_type(name, block=None) -> Type:
                 (name.startswith('::') and
                  canonical_sbtype.GetName() == name[2:])):
                 return Type(canonical_sbtype)
-    # FIXME: When building with `-funsigned-char`, lookups for `char` can fail
-    # because lldb will treat `char` as an alias of `unsigned char`. This is a
-    # bug in lldb, and this hack should be removed once it's fixed.
-    if name == 'char':
-        return lookup_type('unsigned char')
     raise error('Type "%s" not found in %d matches.' % (name, count))
 
 


### PR DESCRIPTION
Use the existing BUILTIN_TYPE_NAME_TO_BASIC_TYPE to quickly return the corresponding builtin type. FindTypes("char") can take a fair amount of time, particularly if the pretty printer does it in a loop, and this can result in significant speedups.

It also allows us to remove the `unsigned char` hackaround.