### PR TITLE
Add two gala_compatibility wrappers for peeking into types

### DIFF
--- a/gdb_modules/gala_compatibility.py
+++ b/gdb_modules/gala_compatibility.py
@@ -6,6 +6,10 @@ the gdb API, in a way that's compatible with both debuggers.
 import gdb
 import gdb.printing
 
+IN_LLDB = hasattr(gdb, "__lldb_init_module")
+IN_GDB = not IN_LLDB
+
+
 class TypeCallbackPrettyPrinter(gdb.printing.PrettyPrinter):
   """A type-callback prettyprinter compatible with GDB and lldb-with-GALA."""
 
@@ -41,3 +45,54 @@ class TypeCallbackPrettyPrinter(gdb.printing.PrettyPrinter):
     return None
 
 
+def get_nested_type(containing_type, nested_type_name):
+  """Finds a type nested in another type.
+
+  Given a code like `struct A { struct B{}; };`, get_nested_type(reference_to_A,
+  "B") returns a reference to the A::B class.
+
+  Args:
+    containing_type: gdb.Type referencing the containing type.
+    nested_type_name: Name of the nested type.
+
+  Returns:
+    gdb.Type referring to the nested type, if it exists.
+  """
+  if IN_LLDB:
+    # LLDB has a dedicated API for this functionality.
+    nested_type = containing_type.sbtype().FindDirectNestedType(nested_type_name)
+    if nested_type.IsValid():
+      return gdb.Type(nested_type)
+    raise gdb.error("There is no type named %s" % nested_type_name)
+  else:
+    # In GDB we have to look up the type by name.
+    return gdb.lookup_type(containing_type.name + "::" + nested_type_name)
+
+
+def get_static_constexpr_value_from_type(containing_type, value_name):
+  """Finds a static member in a type.
+
+  Given code like `struct A { static constexpr int b = 47; };`,
+  get_static_constexpr_value_from_type(reference_to_A, "b") returns `gdb.Value(47)`.
+
+  Args:
+    containing_type: gdb.Type referencing the containing type.
+    value_name: Name of the contained static member.
+
+  Returns:
+    gdb.Value referring to the static member, if it exists.
+  """
+  if IN_LLDB:
+    # Use the dedicated LLDB API.
+    field = containing_type.sbtype().GetStaticFieldWithName(value_name)
+    if not field.IsValid():
+      raise gdb.error("There is no static field named %s" % value_name)
+    value = field.GetConstantValue(gdb.gala_get_current_target())
+    if not value.IsValid():
+      raise gdb.error("%s is not a constexpr field" % value_name)
+    return gdb.Value(value)
+  else:
+    # GDB's Value API can obtain static members, but it requires an instance of
+    # that class. Since we don't have one (it may not even exists), we create
+    # a bogus value from a null pointer.
+    return gdb.Value(0).cast(containing_type.pointer()).dereference()[value_name]

--- a/test/lit/lookup_in_type.test
+++ b/test/lit/lookup_in_type.test
@@ -1,0 +1,18 @@
+RUN: %clangxx -g -o %t lookup_in_type/test_program.cc
+RUN: %lldb -b \
+RUN:       -o 'script import gala_compatibility' \
+RUN:       -o 'script Foo = gdb.lookup_type("Foo")' \
+RUN:       -o 'script print("Foo::Bar = ", gala_compatibility.get_nested_type(Foo, "Bar").name)' \
+RUN:       -o 'script gala_compatibility.get_nested_type(Foo, "Baz")' \
+RUN:       -o 'script print("Foo::bar = ", gala_compatibility.get_static_constexpr_value_from_type(Foo, "bar"))' \
+RUN:       -o 'script gala_compatibility.get_static_constexpr_value_from_type(Foo, "baz")' \
+RUN:       -o 'script gala_compatibility.get_static_constexpr_value_from_type(Foo, "mutable_bar")' \
+RUN:       %t | FileCheck %s
+
+CHECK: (lldb) script import gala_compatibility
+
+CHECK: Foo::Bar = Foo::Bar
+CHECK: gdb.error: There is no type named Baz
+CHECK: Foo::bar = 47
+CHECK: gdb.error: There is no static field named baz
+CHECK: gdb.error: mutable_bar is not a constexpr field

--- a/test/lit/lookup_in_type/test_program.cc
+++ b/test/lit/lookup_in_type/test_program.cc
@@ -1,0 +1,10 @@
+struct Foo {
+  struct Bar {};
+  static constexpr int bar = 47;
+  static int mutable_bar;
+};
+
+Foo::Bar bar;
+int Foo::mutable_bar = 42;
+
+int main() {}


### PR DESCRIPTION
- get_nested_type allows us to use the dedicated lldb api for retrieving the nested type. gdb has no comparable API, so this function is implemented through gdb.lookup_type (which is faster and more reliable than lldb-via-gala implementation of gdb.lookup_type)
- get_static_constexpr_value_from_type allows one to retrieve a static constexpr field from a type. LLDB has a (freshly minted) API for this purpose, while on gdb we can use a hackaround casting a null pointer to a value of the desired type.