### PR TITLE
Move lookup_in_type commands into a python file

### DIFF
--- a/test/lit/lookup_in_type.test
+++ b/test/lit/lookup_in_type.test
@@ -1,18 +1,8 @@
 RUN: %clangxx -g -o %t lookup_in_type/test_program.cc
-RUN: %lldb -b \
-RUN:       -o 'script import gala_compatibility' \
-RUN:       -o 'script Foo = gdb.lookup_type("Foo")' \
-RUN:       -o 'script print("Foo::Bar = ", gala_compatibility.get_nested_type(Foo, "Bar").name)' \
-RUN:       -o 'script gala_compatibility.get_nested_type(Foo, "Baz")' \
-RUN:       -o 'script print("Foo::bar = ", gala_compatibility.get_static_constexpr_value_from_type(Foo, "bar"))' \
-RUN:       -o 'script gala_compatibility.get_static_constexpr_value_from_type(Foo, "baz")' \
-RUN:       -o 'script gala_compatibility.get_static_constexpr_value_from_type(Foo, "mutable_bar")' \
-RUN:       %t | FileCheck %s
+RUN: %lldb -b -o "script import lookup_in_type" %t | FileCheck %s
 
-CHECK: (lldb) script import gala_compatibility
-
-CHECK: Foo::Bar = Foo::Bar
-CHECK: gdb.error: There is no type named Baz
-CHECK: Foo::bar = 47
-CHECK: gdb.error: There is no static field named baz
-CHECK: gdb.error: mutable_bar is not a constexpr field
+CHECK: Foo::Bar: Foo::Bar
+CHECK: Foo::Baz: There is no type named Baz
+CHECK: Foo::bar: 47
+CHECK: Foo::baz: There is no static field named baz
+CHECK: Foo::mutable_bar: mutable_bar is not a constexpr field

--- a/test/lit/lookup_in_type/__init__.py
+++ b/test/lit/lookup_in_type/__init__.py
@@ -1,0 +1,26 @@
+import gala_compatibility
+import gdb
+
+
+def test(name, f):
+    try:
+        print("%s: %s\n" % (name, f()))
+    except gdb.error as e:
+        print("%s: %s\n" % (name, e))
+
+
+Foo = gdb.lookup_type("Foo")
+test("Foo::Bar", lambda: gala_compatibility.get_nested_type(Foo, "Bar").name)
+test("Foo::Baz", lambda: gala_compatibility.get_nested_type(Foo, "Baz").name)
+test(
+    "Foo::bar",
+    lambda: gala_compatibility.get_static_constexpr_value_from_type(Foo, "bar"),
+)
+test(
+    "Foo::baz",
+    lambda: gala_compatibility.get_static_constexpr_value_from_type(Foo, "baz"),
+)
+test(
+    "Foo::mutable_bar",
+    lambda: gala_compatibility.get_static_constexpr_value_from_type(Foo, "mutable_bar"),
+)


### PR DESCRIPTION
Following up on #14. Since some of the checks involve throwing exceptions, I needed to add a small wrapper to catch them.