### PR TITLE
Use SBType::FindFirstType for gdb.lookup_type

### DIFF
--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -989,21 +989,13 @@ def parse_and_eval(expr) -> Value:
 def lookup_type(name, block=None) -> Type:
     if name in BUILTIN_TYPE_NAME_TO_BASIC_TYPE:
         return Type(get_builtin_sbtype(name))
-    chunks = name.split('::')
-    unscoped_name = chunks[-1]
-    typelist = gala_get_current_target().FindTypes(unscoped_name)
-    count = typelist.GetSize()
-    for i in range(count):
-        t = typelist.GetTypeAtIndex(i)
-        if t.GetName() == name:
-            return Type(t)
-        else:
-            canonical_sbtype = t.GetCanonicalType()
-            if (canonical_sbtype.GetName() == name or
-                (name.startswith('::') and
-                 canonical_sbtype.GetName() == name[2:])):
-                return Type(canonical_sbtype)
-    raise error('Type "%s" not found in %d matches.' % (name, count))
+    # GDB lookups are always absolute, whereas lldb will return a type from
+    # within any context unless the name is absolute.
+    name_to_lookup = name if name.startswith('::') else '::' + name
+    t = gala_get_current_target().FindFirstType(name_to_lookup)
+    if not t:
+        raise error('No type named %s.' % name)
+    return Type(t)
 
 
 class Objfile:

--- a/test/lit/lookup_type.test
+++ b/test/lit/lookup_type.test
@@ -1,6 +1,14 @@
 ; RUN: %clangxx -g -o %t lookup_type/lookup_type.cc
 ; RUN: %lldb -b -o 'script import lookup_type' %t | FileCheck %s
-CHECK: t1.name = MyClass
-CHECK: t2.name = MyClass
-CHECK: lookup of non-existing type -> gdb.error
 
+CHECK: int => int
+CHECK: MyClass => MyClass
+CHECK: ::MyClass => MyClass
+CHECK: ns::ClassInNS => ns::ClassInNS
+CHECK: ::ns::ClassInNS => ns::ClassInNS
+CHECK: ns::MyClass => No type named ns::MyClass.
+CHECK: ::NonExistingType => No type named ::NonExistingType.
+
+CHECK: Templated<int>::InTemplate => Templated<int>::InTemplate
+CHECK: Templated<ns::ClassInNS>::InTemplate => Templated<ns::ClassInNS>::InTemplate
+CHECK: Templated<ns::ClassInNS>::MoreTemplates<ns::ClassInNS> => Templated<ns::ClassInNS>::MoreTemplates<ns::ClassInNS>

--- a/test/lit/lookup_type/__init__.py
+++ b/test/lit/lookup_type/__init__.py
@@ -1,12 +1,20 @@
 import gdb
 
-t1 = gdb.lookup_type("MyClass")
-print("t1.name = %s" % t1.name)
+def test(name):
+  try:
+    t = gdb.lookup_type(name)
+    print("%s => %s" % (name, t.name))
+  except gdb.error as e:
+    print("%s => %s" % (name, e))
 
-t2 = gdb.lookup_type("::MyClass")
-print("t2.name = %s" % t2.name)
+test("int")
+test("MyClass")
+test("::MyClass")
+test("ns::ClassInNS")
+test("::ns::ClassInNS")
+test("ns::MyClass")
+test("::NonExistingType")
 
-try:
-  gdb.lookup_type("::NonExistingType")
-except gdb.error as e:
-  print("lookup of non-existing type -> gdb.error: %s" % e)
+test("Templated<int>::InTemplate")
+test("Templated<ns::ClassInNS>::InTemplate")
+test("Templated<ns::ClassInNS>::MoreTemplates<ns::ClassInNS>")

--- a/test/lit/lookup_type/lookup_type.cc
+++ b/test/lit/lookup_type/lookup_type.cc
@@ -1,3 +1,20 @@
-class MyClass{};
+class MyClass {};
 MyClass x;
+
+namespace ns {
+class ClassInNS {};
+ClassInNS class_in_ns;
+}  // namespace ns
+
+template <typename T>
+struct Templated {
+  struct InTemplate {};
+  template <typename U>
+  struct MoreTemplates {};
+};
+
+Templated<int>::InTemplate in_template;
+Templated<ns::ClassInNS>::InTemplate in_complex_template;
+Templated<ns::ClassInNS>::MoreTemplates<ns::ClassInNS> more_templates;
+
 int main() { return 0; }


### PR DESCRIPTION
.. instead of `FindTypes(basename)` + custom filtering.

This makes a huge difference when it comes to performance, because something like `FindTypes("iterator")` forces lldb to return all iterator types anywhere in the program. FindFirstType bails out the search as soon as it finds the first match (which is all that we're interested in).

It's unclear why the function was implemented as it was, but a part of the reason was likely the fact that FindTypes had problems with looking up/parsing compex type names containing templates. This has now been (mostly) fixed in llvm/llvm-project#91586, and appears that the simplified version performs satisfactorily.