### PR TITLE
Add a pretty printer extension to directly return the number of children

### DIFF
--- a/test/lit/num_children.test
+++ b/test/lit/num_children.test
@@ -1,0 +1,20 @@
+Test our num_children pretty printer extension.
+
+RUN: %clangxx -g -o %t num_children/test_program.cc
+RUN: %lldb %t -b \
+RUN:       -o 'settings set target.max-children-count 142' \
+RUN:       -o 'script import num_children' \
+RUN:       -o 'script print("num_children = ", lldb.target.FindFirstGlobalVariable("s").GetNumChildren(47))' \
+RUN:       -o 'script print("MAX_MAX_COUNT = ", num_children.MyStructPrinter.MAX_MAX_COUNT)' \
+RUN:       -o 'target variable s' \
+RUN:       -o 'script print("MAX_MAX_COUNT = ", num_children.MyStructPrinter.MAX_MAX_COUNT)' \
+RUN:       | FileCheck %s
+
+CHECK: num_children = 2
+CHECK: MAX_MAX_COUNT = 94
+CHECK: (MyStruct) s = A pretty MyStruct {
+CHECK-NEXT:  [key0] = "val0"
+CHECK-NEXT:  [key1] = "val1"
+CHECK-NEXT: }
+# 2 * (142 + 1)
+CHECK: MAX_MAX_COUNT = 286

--- a/test/lit/num_children/__init__.py
+++ b/test/lit/num_children/__init__.py
@@ -1,0 +1,29 @@
+import gdb
+import gdb.printing
+
+class MyStructPrinter:
+  MAX_MAX_COUNT = 0
+
+  def __init__(self, val):
+    self._val = val
+
+  def display_hint(self):
+    return "map"
+
+  def to_string(self):
+    return "A pretty MyStruct"
+
+  def num_children(self, max_count):
+    MyStructPrinter.MAX_MAX_COUNT = max(MyStructPrinter.MAX_MAX_COUNT, max_count)
+    return 4
+
+  def children(self):
+    yield "key[0]", "key0"
+    yield "val[0]", "val0"
+    yield "key[1]", "key1"
+    yield "val[1]", "val1"
+
+printer = gdb.printing.RegexpCollectionPrettyPrinter("test_regexp_printer")
+printer.add_printer("MyStruct", "MyStruct", MyStructPrinter)
+
+gdb.printing.register_pretty_printer(gdb.current_objfile(), printer)

--- a/test/lit/num_children/test_program.cc
+++ b/test/lit/num_children/test_program.cc
@@ -1,0 +1,5 @@
+struct MyStruct {};
+
+MyStruct s;
+
+int main() { return 0; }


### PR DESCRIPTION
This avoids us needing to enumerate the children one by one (if the pretty printer supports the extension).

To keep the pretty printer interface consistent, I've define the extensions in terms of the number of children returned/yielded by the `children()` function rather than the number of entries in a map, even though this means that most map pretty printers will need to multiple the number of elemnts by two, only for GALA to divide it again.

I'm also passing down the `max_count` value we get from lldb, in it's useful in some pretty printers for limiting the amount of work.

With llvm/llvm-project#93946, lldb will pass down reasonable values for max_count, so we might be able to remove the limiting hack on the fallback path, but I'm leaving that for a separate patch/discussion.