### PR TITLE
Update gdb.Value.__str__ to iterate through, and return, children val…

### DIFF
--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -640,8 +640,12 @@ class Value(object):
         if type_flags & lldb.eTypeIsPointer:
             return "0x%x" % self._as_number()
 
-        if (t.GetTypeClass() == lldb.eTypeClassClass):
-            return str(self._sbvalue_object.GetSyntheticValue())
+        # Check for synthetic children.
+        if (t.GetTypeClass() == lldb.eTypeClassStruct):
+            valstr = str(self._sbvalue_object.GetSyntheticValue())
+            if (valstr != "No value" and
+                valstr.find("$1") == -1):
+                return valstr
         valstr = self._sbvalue_object.GetSummary()
         if not valstr:
             valstr = self._sbvalue_object.GetValue()

--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -640,6 +640,8 @@ class Value(object):
         if type_flags & lldb.eTypeIsPointer:
             return "0x%x" % self._as_number()
 
+        if (t.GetTypeClass() == lldb.eTypeClassClass):
+            return str(self._sbvalue_object.GetSyntheticValue())
         valstr = self._sbvalue_object.GetSummary()
         if not valstr:
             valstr = self._sbvalue_object.GetValue()

--- a/test/lit/print_elements.test
+++ b/test/lit/print_elements.test
@@ -7,7 +7,7 @@ RUN: %lldb -b -o 'command script import print_elements' %t | FileCheck %s
 Check target.max-children-count values are correctly translated to "print
 elements" values.
 
-CHECK: gdb.parameter('print elements'): None
+CHECK: gdb.parameter('print elements'): 256
 CHECK: gdb.parameter('print elements'): 0
 CHECK: gdb.parameter('print elements'): 10
 
@@ -19,4 +19,9 @@ In this case, for 'set print elements 10' we would print children 0-9 and also
 yield child 10. So check that we don't yield 11.
 
 CHECK: yielding child 10
+CHECK-NOT: yielding child 11
+
+
+CHECK: yielding child 10
+CHECK: A TestStruct of size 100
 CHECK-NOT: yielding child 11

--- a/test/lit/print_elements/__init__.py
+++ b/test/lit/print_elements/__init__.py
@@ -34,7 +34,7 @@ def __lldb_init_module(debugger, internal_dict):
   gdb.printing.register_pretty_printer(gdb.current_objfile(), printer)
 
   # lldb treats all negative values here as 'unlimited'.
-  # gdb.parameter('print elements') returns None in this case.
+  # gdb.parameter('print elements') returns 256 in this case.
   debugger.HandleCommand('settings set -- target.max-children-count -99')
   print("gdb.parameter('print elements'):", gdb.parameter('print elements'))
 
@@ -51,3 +51,5 @@ def __lldb_init_module(debugger, internal_dict):
   print("gdb.parameter('print elements'):", gdb.parameter('print elements'))
 
   debugger.HandleCommand('p s')
+
+  debugger.HandleCommand("script print(gdb.parse_and_eval('s'))")


### PR DESCRIPTION
Update "gdb.Value.__str__" to check synthetic values.

This updates gdb.Value.__str__ to iterate through, and return,  synthetic children values if there are any, when it is appropriate. It also fixes a small bug in print_elements.test (the assumed return value for negative numbers is incorrect), and updates that test to test this new functionality.