### PR TITLE
Update gdb.Value.__str__ to check synthetic values.

### DIFF
--- a/gdb/__init__.py
+++ b/gdb/__init__.py
@@ -640,6 +640,12 @@ class Value(object):
         if type_flags & lldb.eTypeIsPointer:
             return "0x%x" % self._as_number()
 
+        # Check for synthetic children.
+        if (t.GetTypeClass() == lldb.eTypeClassStruct):
+            valstr = str(self._sbvalue_object.GetSyntheticValue())
+            if (valstr != "No value" and
+                valstr.find("$1") == -1):
+                return valstr
         valstr = self._sbvalue_object.GetSummary()
         if not valstr:
             valstr = self._sbvalue_object.GetValue()

--- a/test/lit/address.test
+++ b/test/lit/address.test
@@ -9,9 +9,11 @@ CHECK: ref.address = [[SADDR]]
 
 Check that when we have a prettyprinter, address still works (i.e. we don't
 accidentally end up with a synthetic value from the prettyprinter).
-CHECK: Pretty s = pretty MyStruct
+CHECK: Pretty s ={{.*}}pretty MyStruct
+CHECK: pretty_x
 CHECK: s.address = [[SADDR]]
 
 Finally, check that ref is prettyprinted and taking its address still works.
-CHECK: Pretty ref = pretty MyStruct
+CHECK: Pretty ref ={{.*}}pretty MyStruct
+CHECK: pretty_x
 CHECK: ref.address = [[SADDR]]

--- a/test/lit/address/__init__.py
+++ b/test/lit/address/__init__.py
@@ -28,16 +28,14 @@ print("ref.type = %s" % ref.type)
 print("ref.address = %x" % ref.address)
 
 class MyStructPrinter:
-  """Reads the size member and emits as many synthetic children.
-
-  This gives us an easy way to test `set print elements`.
-  """
-
   def __init__(self, val):
     self.val = val
 
   def to_string(self):
     return "pretty MyStruct"
+
+  def children(self):
+    yield "pretty_x", self.val["x"]
 
 printer = gdb.printing.RegexpCollectionPrettyPrinter("my_struct_printer")
 printer.add_printer("my_struct_printer", "^MyStruct$", MyStructPrinter)

--- a/test/lit/print_elements.test
+++ b/test/lit/print_elements.test
@@ -7,7 +7,6 @@ RUN: %lldb -b -o 'command script import print_elements' %t | FileCheck %s
 Check target.max-children-count values are correctly translated to "print
 elements" values.
 
-CHECK: gdb.parameter('print elements'): 256
 CHECK: gdb.parameter('print elements'): 0
 CHECK: gdb.parameter('print elements'): 10
 

--- a/test/lit/print_elements.test
+++ b/test/lit/print_elements.test
@@ -7,7 +7,7 @@ RUN: %lldb -b -o 'command script import print_elements' %t | FileCheck %s
 Check target.max-children-count values are correctly translated to "print
 elements" values.
 
-CHECK: gdb.parameter('print elements'): None
+CHECK: gdb.parameter('print elements'): 256
 CHECK: gdb.parameter('print elements'): 0
 CHECK: gdb.parameter('print elements'): 10
 
@@ -19,4 +19,8 @@ In this case, for 'set print elements 10' we would print children 0-9 and also
 yield child 10. So check that we don't yield 11.
 
 CHECK: yielding child 10
+CHECK-NOT: yielding child 11
+
+CHECK: yielding child 10
+CHECK: A TestStruct of size 100
 CHECK-NOT: yielding child 11

--- a/test/lit/print_elements/__init__.py
+++ b/test/lit/print_elements/__init__.py
@@ -34,7 +34,7 @@ def __lldb_init_module(debugger, internal_dict):
   gdb.printing.register_pretty_printer(gdb.current_objfile(), printer)
 
   # lldb treats all negative values here as 'unlimited'.
-  # gdb.parameter('print elements') returns None in this case.
+  # gdb.parameter('print elements') returns 256 in this case.
   debugger.HandleCommand('settings set -- target.max-children-count -99')
   print("gdb.parameter('print elements'):", gdb.parameter('print elements'))
 
@@ -51,3 +51,5 @@ def __lldb_init_module(debugger, internal_dict):
   print("gdb.parameter('print elements'):", gdb.parameter('print elements'))
 
   debugger.HandleCommand('p s')
+
+  debugger.HandleCommand("script print(gdb.parse_and_eval('s'))")

--- a/test/lit/print_elements/__init__.py
+++ b/test/lit/print_elements/__init__.py
@@ -33,11 +33,6 @@ def __lldb_init_module(debugger, internal_dict):
   printer.add_printer("TestStruct", "TestStruct", TestStructPrinter)
   gdb.printing.register_pretty_printer(gdb.current_objfile(), printer)
 
-  # lldb treats all negative values here as 'unlimited'.
-  # gdb.parameter('print elements') returns 256 in this case.
-  debugger.HandleCommand('settings set -- target.max-children-count -99')
-  print("gdb.parameter('print elements'):", gdb.parameter('print elements'))
-
   # lldb treats 0 as 'skip all children'.
   # gdb.parameter('print elements') doesn't return 0 in this case, as gdb treats
   # it as unlimited and returns None.


### PR DESCRIPTION
This udpates gdb.Value.__str__ to iterate through, and return, synthetic childre values if there are any, when appropriate.  It also fixes a small bug in print_elements.test (the assumed return values for negative numbers is no longer correct), and it updates that test to test this new functionality.