### PR TITLE
Update int_cast test.

### DIFF
--- a/test/lit/int_cast/__init__.py
+++ b/test/lit/int_cast/__init__.py
@@ -1,6 +1,6 @@
 import gdb
 
-print("b1: %d" % gdb.parse_and_eval("numbers.b1"))
-print("(int)b1: %d" % gdb.parse_and_eval("numbers.b1").cast(gdb.lookup_type("int")))
-print("s1: %d" % gdb.parse_and_eval("numbers.s1"))
-print("(int)s1: %d" % gdb.parse_and_eval("numbers.s1").cast(gdb.lookup_type("int")))
+print("b1: %d" % gdb.parse_and_eval("my_numbers.b1"))
+print("(int)b1: %d" % gdb.parse_and_eval("my_numbers.b1").cast(gdb.lookup_type("int")))
+print("s1: %d" % gdb.parse_and_eval("my_numbers.s1"))
+print("(int)s1: %d" % gdb.parse_and_eval("my_numbers.s1").cast(gdb.lookup_type("int")))

--- a/test/lit/int_cast/int_cast.cc
+++ b/test/lit/int_cast/int_cast.cc
@@ -8,7 +8,7 @@ struct Numbers {
   uint16_t s1, s2;
 };
 
-Numbers numbers = {1, 2, 3, 4, 5, 6};
+Numbers my_numbers = {1, 2, 3, 4, 5, 6};
 
 int main() {
   return 0;


### PR DESCRIPTION
Recently int_cast test has started failing with a complaint that 'numbers' is ambiguous (either local variable or std::numbers). This CL changes the name of the local variable to eliminate the ambiguity.