### PR TITLE
Create the err value using SBValue::CreateValueFromData API.

### DIFF
--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -264,7 +264,6 @@ def _make_child_provider_class(
             byte_order = self._sbvalue.GetTarget().GetByteOrder()
             address_byte_size = self._sbvalue.GetTarget().GetAddressByteSize()
             for error_str in self._captured_errors:
-                error_str = 'GALA_ERROR(%s)GALA_ERROR' % error_str
                 data = lldb.SBData.CreateDataFromCString(
                     byte_order, address_byte_size, error_str)
                 data_type = self._sbvalue.GetTarget().GetBasicType(
@@ -275,8 +274,6 @@ def _make_child_provider_class(
                         'LLDB ERROR',
                         # In order for the error to appear as a synthetic child,
                         # we need to create a value from it.
-                        # So we pack it into a raw string literal with a custom
-                        # delimiter to avoid needing to deal with escaping.
                         gdb.Value(
                             self._sbvalue.CreateValueFromData(
                                 'err', data, data_type)

--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -264,9 +264,9 @@ def _make_child_provider_class(
             byte_order = self._sbvalue.GetTarget().GetByteOrder()
             address_byte_size = self._sbvalue.GetTarget().GetAddressByteSize()
             for error_str in self._captured_errors:
+                error_str = 'GALA_ERROR(%s)GALA_ERROR' % error_str
                 data = lldb.SBData.CreateDataFromCString(
-                    byte_order, address_byte_size,
-                    'GALA_ERROR(%s)GALA_ERROR' % error_str)
+                    byte_order, address_byte_size, error_str)
                 data_type = self._sbvalue.GetTarget().GetBasicType(
                     lldb.eBasicTypeChar).GetArrayType(len(error_str))
                 self._children.insert(

--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -264,6 +264,7 @@ def _make_child_provider_class(
             byte_order = self._sbvalue.GetTarget().GetByteOrder()
             address_byte_size = self._sbvalue.GetTarget().GetAddressByteSize()
             for error_str in self._captured_errors:
+                error_str += '\0'
                 data = lldb.SBData.CreateDataFromCString(
                     byte_order, address_byte_size, error_str)
                 data_type = self._sbvalue.GetTarget().GetBasicType(

--- a/gdb/printing.py
+++ b/gdb/printing.py
@@ -264,7 +264,6 @@ def _make_child_provider_class(
             byte_order = self._sbvalue.GetTarget().GetByteOrder()
             address_byte_size = self._sbvalue.GetTarget().GetAddressByteSize()
             for error_str in self._captured_errors:
-                error_str += '\0'
                 data = lldb.SBData.CreateDataFromCString(
                     byte_order, address_byte_size, error_str)
                 data_type = self._sbvalue.GetTarget().GetBasicType(


### PR DESCRIPTION
`SBValue::CreateValueFromData` is much faster than `SBValue::CreateValueFromExpression` when creating err from string.